### PR TITLE
Refine data lookups and embed formatting

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,13 +1,23 @@
+from __future__ import annotations
+
+from discord import Interaction, app_commands
 from discord.ext import commands
-from discord import app_commands, Interaction
+
 
 class Admin(commands.Cog):
-    def __init__(self, bot): self.bot = bot
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
     @app_commands.command(name="admin_reload", description="Reload JSON data from disk")
-    async def admin_reload(self, interaction: Interaction):
+    async def admin_reload(self, interaction: Interaction) -> None:
         if not interaction.user.guild_permissions.manage_guild:
-            return await interaction.response.send_message("Need Manage Server permission.", ephemeral=True)
+            await interaction.response.send_message("Need Manage Server permission.", ephemeral=True)
+            return
+
         await interaction.response.defer(thinking=True, ephemeral=True)
         await self.bot.ds.load_all()
         await interaction.followup.send("Reloaded data.")
-async def setup(bot): await bot.add_cog(Admin(bot))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Admin(bot))

--- a/cogs/buildings.py
+++ b/cogs/buildings.py
@@ -1,14 +1,29 @@
+from __future__ import annotations
+
+from discord import Interaction, app_commands
 from discord.ext import commands
-from discord import app_commands, Interaction
+
 from utils.embeds import building_to_embed
 
+
 class Buildings(commands.Cog):
-    def __init__(self, bot): self.bot = bot
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
     @app_commands.command(name="building", description="Look up a building by name")
-    async def building(self, interaction: Interaction, name: str, level: int | None = None):
+    async def building(
+        self, interaction: Interaction, name: str, level: int | None = None
+    ) -> None:
         await interaction.response.defer(thinking=True, ephemeral=False)
-        b = self.bot.ds.get_building(name)
-        if not b: return await interaction.followup.send(f"Could not find building **{name}**.")
-        canon = next((k for k,v in self.bot.ds.data.get('buildings',{}).items() if v is b), name)
-        await interaction.followup.send(embed=building_to_embed(canon, b, level))
-async def setup(bot): await bot.add_cog(Buildings(bot))
+
+        match = self.bot.ds.lookup_building(name)
+        if not match:
+            await interaction.followup.send(f"Could not find building **{name}**.")
+            return
+
+        canonical_name, building = match
+        await interaction.followup.send(embed=building_to_embed(canonical_name, building, level))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Buildings(bot))

--- a/cogs/heroes.py
+++ b/cogs/heroes.py
@@ -1,14 +1,27 @@
+from __future__ import annotations
+
+from discord import Interaction, app_commands
 from discord.ext import commands
-from discord import app_commands, Interaction
+
 from utils.embeds import hero_to_embed
 
+
 class Heroes(commands.Cog):
-    def __init__(self, bot): self.bot = bot
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
     @app_commands.command(name="hero", description="Look up a hero by name")
-    async def hero(self, interaction: Interaction, name: str):
+    async def hero(self, interaction: Interaction, name: str) -> None:
         await interaction.response.defer(thinking=True, ephemeral=False)
-        h = self.bot.ds.get_hero(name)
-        if not h: return await interaction.followup.send(f"Could not find hero **{name}**.")
-        canon = next((k for k,v in self.bot.ds.data.get('heroes',{}).items() if v is h), name)
-        await interaction.followup.send(embed=hero_to_embed(canon, h))
-async def setup(bot): await bot.add_cog(Heroes(bot))
+
+        match = self.bot.ds.lookup_hero(name)
+        if not match:
+            await interaction.followup.send(f"Could not find hero **{name}**.")
+            return
+
+        canonical_name, hero = match
+        await interaction.followup.send(embed=hero_to_embed(canonical_name, hero))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Heroes(bot))

--- a/cogs/research.py
+++ b/cogs/research.py
@@ -1,14 +1,27 @@
+from __future__ import annotations
+
+from discord import Interaction, app_commands
 from discord.ext import commands
-from discord import app_commands, Interaction
+
 from utils.embeds import research_to_embed
 
+
 class Research(commands.Cog):
-    def __init__(self, bot): self.bot = bot
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
     @app_commands.command(name="research", description="Look up a research item")
-    async def research(self, interaction: Interaction, name: str):
+    async def research(self, interaction: Interaction, name: str) -> None:
         await interaction.response.defer(thinking=True, ephemeral=False)
-        r = self.bot.ds.get_research(name)
-        if not r: return await interaction.followup.send(f"No research found for **{name}**.")
-        canon = next((k for k,v in self.bot.ds.data.get('research',{}).items() if v is r), name)
-        await interaction.followup.send(embed=research_to_embed(canon, r))
-async def setup(bot): await bot.add_cog(Research(bot))
+
+        match = self.bot.ds.lookup_research(name)
+        if not match:
+            await interaction.followup.send(f"No research found for **{name}**.")
+            return
+
+        canonical_name, research_item = match
+        await interaction.followup.send(embed=research_to_embed(canonical_name, research_item))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Research(bot))

--- a/utils/datastore.py
+++ b/utils/datastore.py
@@ -1,51 +1,99 @@
-import json
-from pathlib import Path
-from rapidfuzz import process, fuzz
+from __future__ import annotations
 
-DATA_DIR = Path(__file__).resolve().parents[1] / "data"
-FILES = {
-    "heroes": DATA_DIR / "heroes.json",
-    "buildings": DATA_DIR / "buildings.json",
-    "research": DATA_DIR / "research.json",
-    "events": DATA_DIR / "events.json",
-    "aliases": DATA_DIR / "aliases.json",
-}
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from rapidfuzz import fuzz, process
+
+log = logging.getLogger(__name__)
+
+DATA_FILE_NAMES = ("heroes", "buildings", "research", "events", "aliases")
+
+
+def _default_files(data_dir: Path) -> dict[str, Path]:
+    return {name: data_dir / f"{name}.json" for name in DATA_FILE_NAMES}
+
 
 class DataStore:
-    def __init__(self):
-        self.data = {k: {} for k in FILES}
+    def __init__(self, data_dir: Path | None = None):
+        data_dir = data_dir or Path(__file__).resolve().parents[1] / "data"
+        self._files: dict[str, Path] = _default_files(data_dir)
+        self.data: dict[str, dict[str, Any]] = {name: {} for name in self._files}
 
-    async def load_all(self):
-        for name, path in FILES.items():
+    async def load_all(self) -> None:
+        for name, path in self._files.items():
             self.data[name] = self._load_json(path)
 
-    def _load_json(self, path: Path):
+    def _load_json(self, path: Path) -> dict[str, Any]:
         if not path.exists():
+            log.warning("Data file missing: %s", path)
             return {}
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
-        except Exception:
+            with path.open("r", encoding="utf-8") as fp:
+                loaded = json.load(fp)
+        except json.JSONDecodeError as exc:
+            log.error("Failed to parse %s: %s", path, exc)
             return {}
+        if isinstance(loaded, Mapping):
+            return dict(loaded)
+        log.error("Data file %s did not contain an object at the top level", path)
+        return {}
 
     def _alias(self, name: str) -> str:
         return self.data.get("aliases", {}).get(name, name)
 
-    def _fuzzy_best(self, name: str, bucket: str, cutoff: int = 70):
+    def _fuzzy_best(self, name: str, bucket: str, cutoff: int = 70) -> str | None:
         bucket_dict = self.data.get(bucket, {})
         if not bucket_dict:
             return None
-        choices = list(bucket_dict.keys())
         alias = self._alias(name)
         if alias in bucket_dict:
             return alias
-        res = process.extractOne(alias, choices, scorer=fuzz.WRatio)
-        if not res:
+        choices: Iterable[str] = bucket_dict.keys()
+        result = process.extractOne(alias, choices, scorer=fuzz.WRatio)
+        if not result:
             return None
-        match, score, _ = res
+        match, score, _ = result
         return match if score >= cutoff else None
 
-    def get_hero(self, name): key = self._fuzzy_best(name, "heroes"); return None if key is None else self.data["heroes"][key]
-    def get_building(self, name): key = self._fuzzy_best(name, "buildings"); return None if key is None else self.data["buildings"][key]
-    def get_research(self, name): key = self._fuzzy_best(name, "research"); return None if key is None else self.data["research"][key]
-    def get_event(self, name): key = self._fuzzy_best(name, "events"); return None if key is None else self.data["events"][key]
-    def list_events(self): return self.data.get("events", {}).keys()
+    def _lookup(self, bucket: str, name: str) -> tuple[str, Any] | None:
+        key = self._fuzzy_best(name, bucket)
+        if key is None:
+            return None
+        bucket_dict = self.data.get(bucket, {})
+        if key not in bucket_dict:
+            return None
+        return key, bucket_dict[key]
+
+    def lookup_hero(self, name: str) -> tuple[str, Any] | None:
+        return self._lookup("heroes", name)
+
+    def lookup_building(self, name: str) -> tuple[str, Any] | None:
+        return self._lookup("buildings", name)
+
+    def lookup_research(self, name: str) -> tuple[str, Any] | None:
+        return self._lookup("research", name)
+
+    def lookup_event(self, name: str) -> tuple[str, Any] | None:
+        return self._lookup("events", name)
+
+    def get_hero(self, name: str) -> Any | None:
+        match = self.lookup_hero(name)
+        return None if match is None else match[1]
+
+    def get_building(self, name: str) -> Any | None:
+        match = self.lookup_building(name)
+        return None if match is None else match[1]
+
+    def get_research(self, name: str) -> Any | None:
+        match = self.lookup_research(name)
+        return None if match is None else match[1]
+
+    def get_event(self, name: str) -> Any | None:
+        match = self.lookup_event(name)
+        return None if match is None else match[1]
+
+    def list_events(self) -> list[str]:
+        return sorted(self.data.get("events", {}))

--- a/utils/embeds.py
+++ b/utils/embeds.py
@@ -1,51 +1,253 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
 import discord
-from typing import Dict, Any
 
-def _kv_lines(d: dict, keys=None):
-    if not d: return "—"
-    keys = keys or d.keys()
-    lines = []
-    for k in keys:
-        if k in d:
-            v = d[k]
-            if isinstance(v, (list, tuple)): v = ", ".join(map(str, v))
-            elif isinstance(v, dict): v = ", ".join(f"{kk}: {vv}" for kk, vv in v.items())
-            lines.append(f"**{k}:** {v}")
-    return "\n".join(lines)
+EM_DASH = "\u2014"
 
-def hero_to_embed(name: str, h: Dict[str, Any]) -> discord.Embed:
-    e = discord.Embed(title=f"Hero • {name}")
-    e.add_field(name="Overview", value=_kv_lines({"rarity": h.get("rarity"), "role": h.get("role")}), inline=False)
-    if h.get("stats"): e.add_field(name="Stats", value=_kv_lines(h["stats"], keys=["attack","defense","health"]), inline=False)
-    if h.get("skills"):
-        e.add_field(name="Skills", value="\n".join([f"• **{s.get('name','?')}** — {s.get('description','')}" for s in h["skills"]]), inline=False)
-    if h.get("expedition_bonuses"): e.add_field(name="Expedition", value=_kv_lines(h["expedition_bonuses"]), inline=False)
-    if h.get("growth"): e.add_field(name="Growth", value="\n".join([f"• {x}" for x in h["growth"]]), inline=False)
-    if h.get("sources"): e.add_field(name="Sources", value="\n".join([f"• {x}" for x in h["sources"]]), inline=False)
-    if h.get("notes"): e.add_field(name="Notes", value=h["notes"], inline=False)
-    return e
 
-def building_to_embed(name: str, b: Dict[str, Any], level: int | None = None) -> discord.Embed:
-    e = discord.Embed(title=f"Building • {name}")
-    e.add_field(name="Basics", value=_kv_lines({"type": b.get("type"), "unlock": b.get("unlock")}), inline=False)
-    if b.get("trees"): e.add_field(name="Research Trees", value=", ".join(b["trees"]), inline=False)
-    if b.get("effects"): e.add_field(name="Effects", value="\n".join([f"• {x}" for x in b["effects"]]), inline=False)
-    if b.get("notes"): e.add_field(name="Notes", value=b["notes"], inline=False)
-    return e
+def _join_lines(lines: Iterable[str]) -> str:
+    items = [line for line in lines if line]
+    return "\n".join(items) if items else EM_DASH
 
-def research_to_embed(name: str, r: Dict[str, Any]) -> discord.Embed:
-    e = discord.Embed(title=f"Research • {name}")
-    return e
 
-def event_to_embed(name: str, ev: Dict[str, Any]) -> discord.Embed:
-    e = discord.Embed(title=f"Event • {name}")
-    return e
+def _format_sequence(values: Sequence[Any]) -> str:
+    if not values:
+        return EM_DASH
+    return _join_lines(f"• {value}" for value in values if value)
 
-def hero_embed(ds): return discord.Embed(title="Hero Lookup", description="Use `/hero name:<text>`.")
-def building_embed(ds): return discord.Embed(title="Building Lookup", description="Use `/building name:<text> [level:<int>]`.")
-def research_embed(ds): return discord.Embed(title="Research Lookup", description="Use `/research name:<text>`.")
-def event_embed(ds): return discord.Embed(title="Events", description="Use `/event` or `/event name:<text>`.")
-def links_embed(ds): 
-    e = discord.Embed(title="Kingshot Links")
-    e.add_field(name="Community Wiki", value="[Kingshot Data](https://kingshotdata.com/)", inline=False)
-    return e
+
+def _format_cost(cost: Mapping[str, Any]) -> str:
+    pairs = [f"{resource}: {amount}" for resource, amount in cost.items() if amount not in (None, "", 0)]
+    return ", ".join(pairs) if pairs else EM_DASH
+
+
+def _format_mapping(data: Mapping[str, Any], keys: Iterable[str] | None = None) -> str:
+    if not data:
+        return EM_DASH
+    lines: list[str] = []
+    for key in keys or data.keys():
+        if key not in data:
+            continue
+        value = data[key]
+        if value in (None, "", []):
+            continue
+        if isinstance(value, Mapping):
+            formatted = _format_mapping(value)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            formatted = ", ".join(str(item) for item in value if item not in (None, "")) or EM_DASH
+        else:
+            formatted = str(value)
+        lines.append(f"**{key.capitalize()}:** {formatted}")
+    return _join_lines(lines)
+
+
+def _format_building_level(data: Mapping[str, Any]) -> str:
+    level = data.get("level")
+    label = f"Level {level}" if level is not None else "Level"
+    parts: list[str] = []
+    cost = data.get("cost")
+    if isinstance(cost, Mapping):
+        formatted = _format_cost(cost)
+        if formatted != EM_DASH:
+            parts.append(f"Cost – {formatted}")
+    time = data.get("time")
+    if time:
+        parts.append(f"Time – {time}")
+    power = data.get("power")
+    if power not in (None, ""):
+        parts.append(f"Power – {power}")
+    for key, value in data.items():
+        if key in {"level", "cost", "time", "power"}:
+            continue
+        if value in (None, ""):
+            continue
+        parts.append(f"{key.capitalize()} – {value}")
+    detail = "; ".join(parts) if parts else None
+    return f"• **{label}:** {detail}" if detail else f"• **{label}**"
+
+
+def hero_to_embed(name: str, hero: Mapping[str, Any]) -> discord.Embed:
+    embed = discord.Embed(title=f"Hero • {name}")
+    embed.add_field(
+        name="Overview",
+        value=_format_mapping({"rarity": hero.get("rarity"), "role": hero.get("role")}),
+        inline=False,
+    )
+
+    stats = hero.get("stats")
+    if isinstance(stats, Mapping):
+        embed.add_field(
+            name="Stats",
+            value=_format_mapping(stats, keys=("attack", "defense", "health")),
+            inline=False,
+        )
+
+    skills = hero.get("skills")
+    if isinstance(skills, Sequence):
+        skill_lines = []
+        for skill in skills:
+            if not isinstance(skill, Mapping):
+                continue
+            title = skill.get("name", "?")
+            desc = skill.get("description", "")
+            line = f"• **{title}**"
+            if desc:
+                line += f" — {desc}"
+            skill_lines.append(line)
+        embed.add_field(name="Skills", value=_join_lines(skill_lines), inline=False)
+
+    expedition = hero.get("expedition_bonuses")
+    if isinstance(expedition, Mapping):
+        embed.add_field(name="Expedition", value=_format_mapping(expedition), inline=False)
+
+    growth = hero.get("growth")
+    if isinstance(growth, Sequence):
+        embed.add_field(name="Growth", value=_format_sequence(growth), inline=False)
+
+    sources = hero.get("sources")
+    if isinstance(sources, Sequence):
+        embed.add_field(name="Sources", value=_format_sequence(sources), inline=False)
+
+    recommended = hero.get("recommended")
+    if isinstance(recommended, Mapping):
+        embed.add_field(name="Recommended", value=_format_mapping(recommended), inline=False)
+
+    notes = hero.get("notes")
+    if notes:
+        embed.add_field(name="Notes", value=str(notes), inline=False)
+
+    return embed
+
+
+def building_to_embed(name: str, building: Mapping[str, Any], level: int | None = None) -> discord.Embed:
+    embed = discord.Embed(title=f"Building • {name}")
+    embed.add_field(
+        name="Basics",
+        value=_format_mapping({"type": building.get("type"), "unlock": building.get("unlock")}),
+        inline=False,
+    )
+
+    trees = building.get("trees")
+    if isinstance(trees, Sequence):
+        embed.add_field(name="Research Trees", value=_format_sequence(trees), inline=False)
+
+    effects = building.get("effects")
+    if isinstance(effects, Sequence):
+        embed.add_field(name="Effects", value=_format_sequence(effects), inline=False)
+
+    levels = [lvl for lvl in building.get("levels", []) if isinstance(lvl, Mapping)]
+    if levels:
+        if level is not None:
+            match = next((lvl for lvl in levels if lvl.get("level") == level), None)
+            if match:
+                embed.add_field(
+                    name=f"Level {level}",
+                    value=_join_lines([_format_building_level(match)]),
+                    inline=False,
+                )
+            else:
+                available_levels = [str(lvl.get("level")) for lvl in levels if lvl.get("level") is not None]
+                available = ", ".join(available_levels) if available_levels else "Unknown"
+                embed.add_field(
+                    name="Level",
+                    value=f"No data for level {level}. Available: {available}.",
+                    inline=False,
+                )
+        else:
+            preview = [_format_building_level(lvl) for lvl in levels[:5]]
+            embed.add_field(
+                name="Levels",
+                value=_join_lines(preview),
+                inline=False,
+            )
+            if len(levels) > 5:
+                embed.add_field(
+                    name="More levels",
+                    value="Use `/building level:<number>` for specific level details.",
+                    inline=False,
+                )
+
+    notes = building.get("notes")
+    if notes:
+        embed.add_field(name="Notes", value=str(notes), inline=False)
+
+    return embed
+
+
+def research_to_embed(name: str, research: Mapping[str, Any]) -> discord.Embed:
+    embed = discord.Embed(title=f"Research • {name}")
+
+    summary_keys = ("tree", "branch", "category", "tier")
+    summary = {key: research.get(key) for key in summary_keys if research.get(key)}
+    if summary:
+        embed.add_field(name="Summary", value=_format_mapping(summary), inline=False)
+
+    bonuses = research.get("bonuses") or research.get("effects")
+    if isinstance(bonuses, Sequence):
+        embed.add_field(name="Effects", value=_format_sequence(bonuses), inline=False)
+
+    requirements = research.get("requirements") or research.get("prerequisites")
+    if isinstance(requirements, Mapping):
+        embed.add_field(name="Requirements", value=_format_mapping(requirements), inline=False)
+    elif isinstance(requirements, Sequence):
+        embed.add_field(name="Requirements", value=_format_sequence(requirements), inline=False)
+
+    costs = research.get("cost") or research.get("costs")
+    if isinstance(costs, Mapping):
+        embed.add_field(name="Cost", value=_format_mapping(costs), inline=False)
+
+    duration = research.get("time") or research.get("duration")
+    if duration:
+        embed.add_field(name="Time", value=str(duration), inline=False)
+
+    notes = research.get("notes")
+    if notes:
+        embed.add_field(name="Notes", value=str(notes), inline=False)
+
+    return embed
+
+
+def event_to_embed(name: str, event: Mapping[str, Any]) -> discord.Embed:
+    embed = discord.Embed(title=f"Event • {name}")
+
+    schedule = {k: event.get(k) for k in ("start", "end", "frequency") if event.get(k)}
+    if schedule:
+        embed.add_field(name="Schedule", value=_format_mapping(schedule), inline=False)
+
+    rewards = event.get("rewards")
+    if isinstance(rewards, Sequence):
+        embed.add_field(name="Rewards", value=_format_sequence(rewards), inline=False)
+
+    tasks = event.get("tasks") or event.get("stages")
+    if isinstance(tasks, Sequence):
+        embed.add_field(name="Tasks", value=_format_sequence(tasks), inline=False)
+
+    notes = event.get("notes")
+    if notes:
+        embed.add_field(name="Notes", value=str(notes), inline=False)
+
+    return embed
+
+
+def hero_embed(ds) -> discord.Embed:  # pragma: no cover - simple factories
+    return discord.Embed(title="Hero Lookup", description="Use `/hero name:<text>`.")
+
+
+def building_embed(ds) -> discord.Embed:  # pragma: no cover - simple factories
+    return discord.Embed(title="Building Lookup", description="Use `/building name:<text> [level:<int>]`.")
+
+
+def research_embed(ds) -> discord.Embed:  # pragma: no cover - simple factories
+    return discord.Embed(title="Research Lookup", description="Use `/research name:<text>`.")
+
+
+def event_embed(ds) -> discord.Embed:  # pragma: no cover - simple factories
+    return discord.Embed(title="Events", description="Use `/event` or `/event name:<text>`.")
+
+
+def links_embed(ds) -> discord.Embed:  # pragma: no cover - simple factories
+    embed = discord.Embed(title="Kingshot Links")
+    embed.add_field(name="Community Wiki", value="[Kingshot Data](https://kingshotdata.com/)", inline=False)
+    return embed


### PR DESCRIPTION
## Summary
- refactor the data store to provide typed lookup helpers and logging when JSON data is missing or invalid
- enrich embed builders to format hero, building, research and event data (including specific building levels)
- simplify the command cogs to use the new lookup helpers and return clearer messaging

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf386ac14c8330a423c266e6fbf5cb